### PR TITLE
Mailto wrapper around instances of 'contact us'

### DIFF
--- a/texaslan/templates/500.html
+++ b/texaslan/templates/500.html
@@ -8,7 +8,7 @@
 
         <h3>Looks like something went wrong!</h3>
 
-        <p>We track these errors automatically, but if the problem persists feel free to contact us. In the meantime,
+        <p>We track these errors automatically, but if the problem persists feel free to <a href="mailto:general@texaslan.org">contact us</a>. In the meantime,
             try
             refreshing.</p>
     </div>

--- a/texaslan/templates/account/password_reset.html
+++ b/texaslan/templates/account/password_reset.html
@@ -21,6 +21,6 @@
         <input type="submit" value="{% trans 'Reset My Password' %}"/>
     </form>
 
-    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Please <a href="mailto:general@texaslan.org">contact us</a> if you have any trouble resetting your password.{% endblocktrans %}</p>
 {% endblock %}
 

--- a/texaslan/templates/account/password_reset_done.html
+++ b/texaslan/templates/account/password_reset_done.html
@@ -12,7 +12,7 @@
         {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
 
-    <p>{% blocktrans %}We have sent you an e-mail. Please contact us if you do not receive it within a few
+    <p>{% blocktrans %}We have sent you an e-mail. Please <a href="mailto:general@texaslan.org">contact us</a> if you do not receive it within a few
         minutes.{% endblocktrans %}</p>
 {% endblock %}
 

--- a/texaslan/templates/account/verification_sent.html
+++ b/texaslan/templates/account/verification_sent.html
@@ -8,7 +8,7 @@
     <h1>{% trans "Verify Your E-mail Address" %}</h1>
 
     <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup
-        process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+        process. Please <a href="mailto:general@texaslan.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
 {% endblock %}
 

--- a/texaslan/templates/account/verified_email_required.html
+++ b/texaslan/templates/account/verified_email_required.html
@@ -15,7 +15,7 @@
 
     <p>{% blocktrans %}We have sent an e-mail to you for
         verification. Please click on the link inside this e-mail. Please
-        contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+        <a href="mailto:general@texaslan.org">contact us</a> if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
     <p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>
         .{% endblocktrans %}</p>


### PR DESCRIPTION
The usage of "contact us" was really vague imo so I added a mailto wrapper. LMK if there is a different preferred address.